### PR TITLE
REMOVE 'tzinfo-data' gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,6 +96,3 @@ group :test do
   gem 'codeclimate-test-reporter', '~> 1.0.0', require: false
   gem 'codacy-coverage', require: false
 end
-
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -420,7 +420,6 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
   sqlite3
   turbolinks (~> 5)
-  tzinfo-data
   uglifier (>= 1.3.0)
   web-console
   wysiwyg-rails


### PR DESCRIPTION
Only for `Windows`, so not needed in my case