### PR TITLE
SETUP Capybara specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,16 @@
 sudo: required
 language: ruby
-cache: bundler
+
+cache:
+  bundler: true
+  directories:
+    - node_modules
+    - travis_phantomjs
+  yarn: true
 bundler_args: --without development
 
 rvm:
   - 2.4.0
-
 env:
   - DB=sqlite
 
@@ -14,10 +19,23 @@ services:
 
 before_install:
   - export TZ=Europe/Paris
+  - nvm install 7.7.0
+  - nvm use 7.7.0
+
+  # Install PhantomJS version 2.1.1
+  - "export PATH=$PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH"
+  - "hash -d phantomjs || true"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then rm -rf $PWD/travis_phantomjs; mkdir -p $PWD/travis_phantomjs; fi"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then wget https://assets.membergetmember.co/software/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2; fi"
+  - "if [ $(phantomjs --version) != '2.1.1' ]; then tar -xvf $PWD/travis_phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis_phantomjs; fi"
 
 before_script:
   - sleep 10
   - cp .env.sample .env
+  - npm i -g yarn@0.21.3
+  - bin/yarn install
+  - npm rebuild node-sass
+  - RAILS_ENV=test bin/rails webpacker:compile
 
 script:
   - RAILS_ENV=test bin/rails --trace db:migrate
@@ -33,6 +51,8 @@ after_failure:
   - cat ./config/database.yml
   - echo $RAILS_ENV
   - bin/rake --version
+  - node --version
+  - phantomjs -v
 
 matrix:
   fast_finish: true

--- a/Gemfile
+++ b/Gemfile
@@ -92,6 +92,10 @@ group :development do
 end
 
 group :test do
+  gem 'capybara', '~> 2.7.0'
+  gem 'capybara-screenshot', require: false
+  gem 'poltergeist', require: false
+
   gem 'shoulda-matchers', '~> 3.1'
   gem 'rails-controller-testing'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,8 @@ GEM
       activerecord (>= 4.0)
       activesupport (>= 4.0)
       awesome_nested_set (>= 3.0)
+    addressable (2.5.1)
+      public_suffix (~> 2.0, >= 2.0.2)
     arel (7.1.4)
     ast (2.3.0)
     awesome_nested_set (3.1.1)
@@ -102,6 +104,16 @@ GEM
       uniform_notifier (~> 1.10.0)
     byebug (9.0.6)
     cancancan (1.16.0)
+    capybara (2.7.1)
+      addressable
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
+    capybara-screenshot (1.0.14)
+      capybara (>= 1.0, < 3)
+      launchy
     carrierwave (1.1.0)
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
@@ -115,6 +127,7 @@ GEM
     client_side_validations-simple_form (6.2.0)
       client_side_validations (~> 9.0)
       simple_form (~> 3.4)
+    cliver (0.3.2)
     codacy-coverage (1.1.6)
       simplecov
     codeclimate-test-reporter (1.0.8)
@@ -201,6 +214,8 @@ GEM
       activerecord
       kaminari-core (= 1.0.1)
     kaminari-core (1.0.1)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -231,6 +246,10 @@ GEM
     parser (2.4.0.0)
       ast (~> 2.2)
     pg (0.20.0)
+    poltergeist (1.14.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      websocket-driver (>= 0.2.0)
     powerpack (0.1.1)
     pry (0.10.4)
       coderay (~> 1.1.0)
@@ -246,6 +265,7 @@ GEM
       pry (>= 0.10.4)
     pry-theme (1.2.0)
       coderay (~> 1.1)
+    public_suffix (2.0.5)
     puma (3.8.2)
     rack (2.0.1)
     rack-test (0.6.3)
@@ -399,6 +419,8 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    xpath (2.0.0)
+      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
@@ -412,6 +434,8 @@ DEPENDENCIES
   binding_of_caller
   bullet
   cancancan
+  capybara (~> 2.7.0)
+  capybara-screenshot
   carrierwave (~> 1.0)
   client_side_validations
   client_side_validations-simple_form
@@ -432,6 +456,7 @@ DEPENDENCIES
   meta-tags
   mini_magick
   pg
+  poltergeist
   pry-alias
   pry-byebug
   pry-rails

--- a/app/javascript/modules/search.js
+++ b/app/javascript/modules/search.js
@@ -7,11 +7,12 @@ $(document).on('turbolinks:load', () => {
     datumTokenizer: Bloodhound.tokenizers.whitespace,
     queryTokenizer: Bloodhound.tokenizers.whitespace,
     remote: {
-      url: ($('#blogs_search').data('autocomplete-path')) + '?query=%QUERY',
+      url: ($('#blogs_search--input').data('autocomplete-path')) + '?query=%QUERY',
       wildcard: '%QUERY'
     }
   })
-  $('#blogs_search').typeahead({
+
+  $('#blogs_search--input').typeahead({
     hint: true,
     highlight: true,
     minLength: 3

--- a/app/views/blogs/_search.html.slim
+++ b/app/views/blogs/_search.html.slim
@@ -3,7 +3,7 @@
                    params[:term],
                    autocomplete: :off,
                    placeholder: 'Search',
-                   id: 'blogs_search',
+                   id: 'blogs_search--input',
                    data: { autocomplete_path: blogs_autocompletes_path }
 
   = submit_tag 'Search', name: nil, class: 'button'

--- a/app/views/blogs/index.html.slim
+++ b/app/views/blogs/index.html.slim
@@ -1,6 +1,6 @@
 - breadcrumb :blogs
 - breadcrumb :blog_category, @category if params[:category_id].present?
-- set_meta_tags title: "#{t('.title')} #{@category.name unless params[:category_id].nil?}",
+- set_meta_tags title: "#{t('.title')}#{' ' + @category.name unless params[:category_id].nil?}",
                 description: t('.description'),
                 keywords: t('.keywords')
 
@@ -10,7 +10,7 @@
       = render 'blogs/search'
 
       - if @blogs.blank?
-        p Il n'y a aucun article de blog à afficher
+        p= t('.empty_records')
       - else
         - @blogs.each do |blog|
           = render 'blogs/blog', blog: blog

--- a/config/locales/blogs.yml
+++ b/config/locales/blogs.yml
@@ -1,5 +1,7 @@
 fr:
   blogs:
+    index:
+      empty_records: Il n'y a aucun article de blog à afficher
     create:
       notice: L'article de Blog a été créé avec succès
     update:

--- a/spec/controllers/blogs/autocompletes_controller_spec.rb
+++ b/spec/controllers/blogs/autocompletes_controller_spec.rb
@@ -6,7 +6,7 @@ describe Blogs::AutocompletesController do
   before(:each) { Blog.reindex }
 
   describe 'GET #index' do
-    subject! { get :index, params: { query: 'title' }, format: :json }
+    subject! { get :index, params: { query: 'article' }, format: :json }
 
     it { is_expected.to have_http_status(:ok) }
 

--- a/spec/controllers/blogs/searches_controller_spec.rb
+++ b/spec/controllers/blogs/searches_controller_spec.rb
@@ -18,7 +18,7 @@ describe Blogs::SearchesController do
     end
 
     context 'with query' do
-      subject! { get :index, params: { term: 'title' } }
+      subject! { get :index, params: { term: 'article' } }
 
       it_behaves_like :ok_request, 'blogs/index'
 

--- a/spec/factories/blogs.rb
+++ b/spec/factories/blogs.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :blog do
-    sequence(:title) { |n| "My title #{n + 1}" }
+    sequence(:title) { |n| "My blog article #{n + 1}" }
     content { Faker::Lorem.paragraph(2) }
     category
     user

--- a/spec/features/blog_spec.rb
+++ b/spec/features/blog_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+feature 'Blog page' do
+  let!(:blogs) { create_list(:blog, 3) }
+
+  subject { BlogPage.new }
+  before { visit blogs_path }
+
+  context 'the index page' do
+    it { is_expected.to have_page_title(action: 'index') }
+    it { is_expected.to have_h1_title(action: 'index') }
+
+    it 'lists the lasts articles' do
+      blogs.each do |blog|
+        expect(page).to have_content(blog.title)
+      end
+    end
+  end
+end

--- a/spec/features/blogs/autocomplete_spec.rb
+++ b/spec/features/blogs/autocomplete_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+feature 'Blogs::Autocomplete', js: true do
+  let!(:blog) { create(:blog, title: 'Lorem ipsum dolor') }
+
+  subject { Blogs::AutocompletePage.new }
+  before { visit blogs_path }
+  before(:each) { Blog.reindex }
+
+  context 'when a record does not exist' do
+    let(:query) { 'query without record' }
+    before { subject.fill_form(query: query) }
+
+    it { is_expected.to have_not_found_records }
+  end
+
+  context 'when a record exists' do
+    let(:query) { 'ipsum' }
+    before { subject.fill_form(query: query) }
+
+    it { is_expected.to have_found_records(title: blog.title) }
+  end
+end

--- a/spec/features/blogs/search_spec.rb
+++ b/spec/features/blogs/search_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+feature 'Blogs::Search', js: true do
+  let!(:blogs) { create_list(:blog, 3) }
+  let!(:blog) { create(:blog, title: 'Lorem ipsum') }
+
+  subject { Blogs::SearchPage.new }
+  before { visit blogs_path }
+  before(:each) { Blog.reindex }
+
+  context 'when a record does not exist' do
+    let(:query) { 'query without record' }
+    before { subject.fill_form(query: query) }
+
+    it { is_expected.to have_not_found_records }
+  end
+
+  context 'when a record exists' do
+    let(:query) { 'ipsum' }
+    before { subject.fill_form(query: query) }
+
+    it { is_expected.to have_found_records(title: blog.title) }
+  end
+end

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+feature 'Home page' do
+  subject { HomePage.new }
+
+  context '#index' do
+    before { visit root_path }
+
+    it { is_expected.to have_correct_page_title }
+    it { is_expected.to have_correct_h1_title }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,9 @@ require 'rspec/rails'
 require 'cancan/matchers'
 require 'carrierwave/test/matchers'
 
+# This is needed by CI to be aware of page objects.
+require Rails.root.join('spec', 'support', 'application_page.rb')
+
 Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 Dir[Rails.root.join('spec', 'features', 'shared_examples', '**', '*.rb')].each do |f|
   require f
@@ -13,7 +16,6 @@ end
 
 RSpec.configure do |config|
   config.extend ControllerMacros, type: :controller
-  config.include FactoryGirl::Syntax::Methods
   config.include AbstractController::Translation
   config.include Devise::Test::ControllerHelpers, type: :controller
 

--- a/spec/support/application_page.rb
+++ b/spec/support/application_page.rb
@@ -1,0 +1,4 @@
+# Page objects support.
+class ApplicationPage
+  include Capybara::DSL
+end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,0 +1,24 @@
+require 'capybara/rails'
+require 'capybara/rspec'
+require 'capybara/poltergeist'
+require 'capybara-screenshot/rspec'
+
+# Capybara
+Capybara.asset_host = 'http://localhost:3000'
+Capybara.save_path = Rails.root.join('tmp', 'capybara')
+Capybara.default_driver = :rack_test
+
+# Poltergeist
+Capybara.javascript_driver = :poltergeist
+Capybara.register_driver :poltergeist do |app|
+  Capybara::Poltergeist::Driver.new(
+    app,
+    js_errors: false,
+    inspector: false,
+    phantomjs_options: ['--load-images=no', '--ignore-ssl-errors=yes'],
+    timeout: 120
+  )
+end
+
+# Capybara Screenshot
+Capybara::Screenshot.prune_strategy = :keep_last_run

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -10,16 +10,19 @@ MSG
 
 RSpec.configure do |config|
   config.before(:suite) do
-    raise(TRANSACTIONAL_FIXTURES_ERROR_MESSAGE) if config.use_transactional_fixtures?
-    DatabaseCleaner.strategy = :transaction
-    DatabaseCleaner.clean_with(:truncation)
+    DatabaseCleaner.clean_with :truncation
   end
 
-  config.before(:each) do
+  config.before(:each) do |example|
+    DatabaseCleaner.strategy = if example.metadata[:js]
+      :truncation
+    else
+      :transaction
+    end
     DatabaseCleaner.start
   end
 
-  config.append_after(:each) do
+  config.after(:each) do
     DatabaseCleaner.clean
   end
 end

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryGirl::Syntax::Methods
+end

--- a/spec/support/pages/blog_page.rb
+++ b/spec/support/pages/blog_page.rb
@@ -1,0 +1,13 @@
+class BlogPage < ApplicationPage
+  TEXTS = {
+    site_name: 'BlogMVC'
+  }.freeze
+
+  def has_page_title?(action:)
+    page.has_title? "#{I18n.t("blogs.#{action}.title")} | #{TEXTS[:site_name]}"
+  end
+
+  def has_h1_title?(action:)
+    page.has_text? I18n.t("blogs.#{action}.title")
+  end
+end

--- a/spec/support/pages/blogs/autocomplete_page.rb
+++ b/spec/support/pages/blogs/autocomplete_page.rb
@@ -1,0 +1,22 @@
+class Blogs::AutocompletePage < ApplicationPage
+  SELECTORS = {
+    form: 'form[role="search"]',
+    input: 'input#blogs_search--input'
+  }.freeze
+
+  def fill_form(query:)
+    within SELECTORS[:form] do
+      fill_in 'term', with: query
+      find(:css, SELECTORS[:input]).trigger('focus')
+    end
+  end
+
+  def has_found_records?(title:)
+    suggestion = page.find('.tt-suggestion')
+    suggestion.has_content?(title)
+  end
+
+  def has_not_found_records?
+    page.has_content? 'Not found'
+  end
+end

--- a/spec/support/pages/blogs/search_page.rb
+++ b/spec/support/pages/blogs/search_page.rb
@@ -1,0 +1,21 @@
+class Blogs::SearchPage < ApplicationPage
+  SELECTORS = {
+    form: 'form[role="search"]',
+    submit: 'input[type="submit"]'
+  }.freeze
+
+  def fill_form(query:)
+    within SELECTORS[:form] do
+      fill_in 'term', with: query
+      find(SELECTORS[:submit]).click
+    end
+  end
+
+  def has_found_records?(title:)
+    page.has_content?(title)
+  end
+
+  def has_not_found_records?
+    page.has_content? I18n.t('blogs.index.empty_records')
+  end
+end

--- a/spec/support/pages/home_page.rb
+++ b/spec/support/pages/home_page.rb
@@ -1,0 +1,14 @@
+class HomePage < ApplicationPage
+  TEXTS = {
+    page_title: "#{I18n.t('homes.index.title')} | BlogMVC",
+    h1_title: I18n.t('homes.index.title')
+  }.freeze
+
+  def has_correct_page_title?
+    page.has_title? TEXTS[:page_title]
+  end
+
+  def has_correct_h1_title?
+    page.has_text? TEXTS[:h1_title]
+  end
+end


### PR DESCRIPTION
SETUP `capybara` acceptances specs to test from the user point of view.

**Details**:
- ADD `capybara` gem
- ADD `capybara-screenshot` gem
- ADD `poltergeist` driver
- FIX `database_cleaner` cleaning strategy for `js` specs
- FIX `rubocop` issues
- UPDATE `travis` node version to work with `webpack`