### PR TITLE
SETUP 'active_model_serializers' gem, DROP 'jbuilder'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem 'retina_rails',
     github: 'gemsfix/retina_rails',
     branch: 'feature/rails5'
 
-gem 'jbuilder', '~> 2.5'
+gem 'active_model_serializers', '~> 0.10.0'
 gem 'webpacker', github: 'rails/webpacker'
 
 gem 'rails-i18n', '~> 5.0.0' # I18n

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,11 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_model_serializers (0.10.6)
+      actionpack (>= 4.1, < 6)
+      activemodel (>= 4.1, < 6)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.2)
     activejob (5.0.2)
       activesupport (= 5.0.2)
       globalid (>= 0.3.6)
@@ -101,6 +106,8 @@ GEM
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
       mime-types (>= 1.16)
+    case_transform (0.2)
+      activesupport
     client_side_validations (9.3.0)
       jquery-rails (~> 4.3)
       js_regex (~> 1.2)
@@ -174,9 +181,6 @@ GEM
       rails (>= 3.1.0)
     hashie (3.5.5)
     i18n (0.8.1)
-    jbuilder (2.6.3)
-      activesupport (>= 3.0.0, < 5.2)
-      multi_json (~> 1.2)
     jquery-rails (4.3.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -184,6 +188,7 @@ GEM
     js_regex (1.2.3)
       regexp_parser (>= 0.3.6, <= 0.5.0)
     json (2.1.0)
+    jsonapi-renderer (0.1.2)
     kaminari (1.0.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.0.1)
@@ -399,6 +404,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers (~> 0.10.0)
   acts-as-taggable-on (~> 4.0)
   acts_as_commentable_with_threading
   annotate!
@@ -420,7 +426,6 @@ DEPENDENCIES
   foundation-rails (~> 6.3.0)
   friendly_id
   gretel
-  jbuilder (~> 2.5)
   kaminari (~> 1.0)
   listen
   lograge

--- a/app/controllers/blogs/autocompletes_controller.rb
+++ b/app/controllers/blogs/autocompletes_controller.rb
@@ -4,5 +4,6 @@ class Blogs::AutocompletesController < ApplicationController
   # GET /blogs/autocompletes.json
   def index
     @blogs = Blog.search(params[:query], Blog.search_opts)
+    render json: @blogs, each_serializer: Blogs::AutocompleteSerializer
   end
 end

--- a/app/serializers/application_serializer.rb
+++ b/app/serializers/application_serializer.rb
@@ -1,0 +1,4 @@
+class ApplicationSerializer < ActiveModel::Serializer
+  include ActionView::Helpers::AssetTagHelper
+  include Rails.application.routes.url_helpers
+end

--- a/app/serializers/blog_serializer.rb
+++ b/app/serializers/blog_serializer.rb
@@ -1,0 +1,3 @@
+class BlogSerializer < ApplicationSerializer
+  attributes :id, :title, :content
+end

--- a/app/serializers/blogs/autocomplete_serializer.rb
+++ b/app/serializers/blogs/autocomplete_serializer.rb
@@ -1,0 +1,12 @@
+class Blogs::AutocompleteSerializer < ApplicationSerializer
+  attributes :title, :url
+  attribute :picture, if: -> { object.picture? }
+
+  def url
+    category_blog_path(object.category, object)
+  end
+
+  def picture
+    retina_image_tag(object.picture, :image, :thumb)
+  end
+end

--- a/app/views/blogs/autocompletes/index.json.jbuilder
+++ b/app/views/blogs/autocompletes/index.json.jbuilder
@@ -1,5 +1,0 @@
-json.array! @blogs.records do |blog|
-  json.title blog.title
-  json.url category_blog_path(blog.category, blog)
-  json.picture retina_image_tag(blog.picture, :image, :thumb) if blog.picture?
-end

--- a/bin/webpack
+++ b/bin/webpack
@@ -31,8 +31,8 @@ rescue Errno::ENOENT, NoMethodError
   exit!
 end
 
-WEBPACK_BIN    = "#{NODE_MODULES_PATH}/.bin/webpack"
-WEBPACK_CONFIG = "#{WEBPACK_CONFIG_PATH}/#{NODE_ENV}.js"
+WEBPACK_BIN    = "#{NODE_MODULES_PATH}/.bin/webpack".freeze
+WEBPACK_CONFIG = "#{WEBPACK_CONFIG_PATH}/#{NODE_ENV}.js".freeze
 
 Dir.chdir(APP_PATH) do
   exec "NODE_PATH=#{NODE_MODULES_PATH} #{WEBPACK_BIN} --config #{WEBPACK_CONFIG}" \

--- a/bin/webpack-dev-server
+++ b/bin/webpack-dev-server
@@ -19,8 +19,8 @@ begin
   NODE_MODULES_PATH   = File.join(APP_PATH.shellescape, paths['node_modules'])
   WEBPACK_CONFIG_PATH = File.join(APP_PATH.shellescape, paths['config'])
 
-  WEBPACK_BIN       = "#{NODE_MODULES_PATH}/.bin/webpack-dev-server"
-  DEV_SERVER_CONFIG = "#{WEBPACK_CONFIG_PATH}/development.server.js"
+  WEBPACK_BIN       = "#{NODE_MODULES_PATH}/.bin/webpack-dev-server".freeze
+  DEV_SERVER_CONFIG = "#{WEBPACK_CONFIG_PATH}/development.server.js".freeze
 rescue Errno::ENOENT, NoMethodError
   puts 'Configuration not found in config/webpacker/paths.yml.'
   puts 'Please run bundle exec rails webpacker:install to install webpacker'

--- a/config/initializers/active_model_serializer.rb
+++ b/config/initializers/active_model_serializer.rb
@@ -1,0 +1,1 @@
+ActiveModelSerializers.config.adapter = :attributes

--- a/spec/serializers/blog_serializer_spec.rb
+++ b/spec/serializers/blog_serializer_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe BlogSerializer, type: :serializer do
+  let(:blog) { create(:blog) }
+  subject { serialize(blog) }
+
+  it 'includes the expected attributes' do
+    expected = {
+      id: blog.id,
+      title: blog.title,
+      content: blog.content
+    }.to_json
+
+    expect(subject).to eq expected
+  end
+end

--- a/spec/serializers/blogs/autocomplete_serializer_spec.rb
+++ b/spec/serializers/blogs/autocomplete_serializer_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe Blogs::AutocompleteSerializer, type: :serializer do
+  include Rails.application.routes.url_helpers
+
+  let(:blog) { create(:blog) }
+  subject { serialize(blog, serializer_class: described_class) }
+
+  it 'includes the expected attributes' do
+    expected = {
+      title: blog.title,
+      url: category_blog_path(blog.category, blog)
+    }.to_json
+
+    expect(subject).to eq expected
+  end
+end

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,4 +1,4 @@
-TRANSACTIONAL_FIXTURES_ERROR_MESSAGE = <<-MSG
+TRANSACTIONAL_FIXTURES_ERROR_MESSAGE = <<-MSG.freeze
   Delete line `config.use_transactional_fixtures = true` from rails_helper.rb
   (or set it to false) to prevent uncommitted transactions being used in
   JavaScript-dependent specs.

--- a/spec/support/serializer_spec_helper.rb
+++ b/spec/support/serializer_spec_helper.rb
@@ -1,5 +1,5 @@
 module SerializerSpecHelper
-  def serialize(obj, opts={})
+  def serialize(obj, opts = {})
     serializer_class = opts.delete(:serializer_class) || "#{obj.class.name}Serializer".constantize
     serializer = serializer_class.send(:new, obj)
     adapter = ActiveModelSerializers::Adapter.create(serializer, opts)

--- a/spec/support/serializer_spec_helper.rb
+++ b/spec/support/serializer_spec_helper.rb
@@ -1,0 +1,12 @@
+module SerializerSpecHelper
+  def serialize(obj, opts={})
+    serializer_class = opts.delete(:serializer_class) || "#{obj.class.name}Serializer".constantize
+    serializer = serializer_class.send(:new, obj)
+    adapter = ActiveModelSerializers::Adapter.create(serializer, opts)
+    adapter.to_json
+  end
+end
+
+RSpec.configure do |config|
+  config.include SerializerSpecHelper, type: :serializer
+end


### PR DESCRIPTION
REPLACE `jbuilder` by `active_model_serializers` gem and use it to render `Blogs::Autocomplete` json. 
Rendering a json object from a serializer class is a better approach than to define properties in a view in my opinion.

**Details**:
- REPLACE `jbuilder` by `active_model_serializers` gem
- ADD corresponding specs for `Blogs::AutocompleteSerializer` and `BlogSerializer`