### PR TITLE
DROP 'retina_rails' gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,9 +38,6 @@ gem 'searchkick'
 # Uploaders
 gem 'mini_magick'
 gem 'carrierwave', '~> 1.0'
-gem 'retina_rails',
-    github: 'gemsfix/retina_rails',
-    branch: 'feature/rails5'
 
 gem 'active_model_serializers', '~> 0.10.0'
 gem 'webpacker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,14 +16,6 @@ GIT
       activerecord (>= 3.2, < 6.0)
       rake (>= 10.4)
 
-GIT
-  remote: https://github.com/gemsfix/retina_rails.git
-  revision: f512f568173376db836421ef791d68407ec238c3
-  branch: feature/rails5
-  specs:
-    retina_rails (2.0.4)
-      rails (>= 3.2.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -488,7 +480,6 @@ DEPENDENCIES
   rails-controller-testing
   rails-i18n (~> 5.0.0)
   reform-rails
-  retina_rails!
   rspec-rails (~> 3.5)
   rubocop
   sassc-rails

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,4 +2,19 @@ module ApplicationHelper
   def website_conf
     @website_conf ||= Rails.configuration.website
   end
+
+  def retina_image_tag(model, mounted_to, version, options = {})
+    options.symbolize_keys!
+    options[:srcset] ||= (2..3).map do |multiplier|
+                            name = "#{version}_#{multiplier}x"
+                            if model.send(mounted_to).version_exists?(name) &&
+                              source = model.send(mounted_to).url(name).presence
+                              "#{source} #{multiplier}x"
+                            else
+                              nil
+                            end
+                          end.compact.join(', ')
+
+    image_tag(model.send(mounted_to).url(version), options)
+  end
 end

--- a/app/models/picture.rb
+++ b/app/models/picture.rb
@@ -13,13 +13,12 @@ end
 #
 # Table name: pictures
 #
-#  id                :integer          not null, primary key
-#  attachable_type   :string
-#  attachable_id     :integer
-#  image             :string
-#  retina_dimensions :text
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
+#  id              :integer          not null, primary key
+#  attachable_type :string
+#  attachable_id   :integer
+#  image           :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
 #
 # Indexes
 #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -71,7 +71,6 @@ end
 #  role                   :integer          default("author")
 #  blogs_count            :integer          default(0), not null
 #  avatar                 :string
-#  retina_dimensions      :text
 #  comments_count         :integer          default(0), not null
 #
 # Indexes

--- a/app/uploaders/application_uploader.rb
+++ b/app/uploaders/application_uploader.rb
@@ -1,8 +1,6 @@
 class ApplicationUploader < CarrierWave::Uploader::Base
   include CarrierWave::MiniMagick
 
-  retina!
-
   def store_dir
     "uploads/#{model.class.to_s.underscore}/#{model.id}"
   end

--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -6,20 +6,20 @@ class AvatarUploader < ApplicationUploader
     "//gravatar.com/avatar/#{gravatar_id}.png?s=400&r=g&d=identicon"
   end
 
-  version :large do
+  version :large_2x do
     process resize_to_fill: [400, 400]
   end
 
-  version :medium do
+  version :large, from_version: :large_2x do
     process resize_to_fill: [200, 200]
   end
 
-  version :small do
-    process resize_to_fill: [100, 100]
+  version :small_2x, from_version: :large do
+    process resize_to_fill: [200, 200]
   end
 
-  version :thumb do
-    process resize_to_fill: [50, 50]
+  version :small, from_version: :small_2x do
+    process resize_to_fill: [100, 100]
   end
 
   def size_range

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -5,19 +5,35 @@ class ImageUploader < ApplicationUploader
     "uploads/#{model.class.to_s.underscore}/#{model.attachable_id}"
   end
 
-  version :large do
-    process resize_to_fit: [512, 512]
+  version :large_2x do
+    process resize_to_fit: [1200, 1200]
   end
 
-  version :medium do
-    process resize_to_fit: [256, 256]
+  version :large, from_version: :large_2x do
+    process resize_to_fit: [600, 600]
   end
 
-  version :small do
+  version :medium_2x, from_version: :large do
+    process resize_to_fit: [600, 600]
+  end
+
+  version :medium, from_version: :medium_2x do
+    process resize_to_fit: [300, 300]
+  end
+
+  version :small_2x, from_version: :medium do
+    process resize_to_fit: [300, 300]
+  end
+
+  version :small, from_version: :small_2x do
+    process resize_to_fit: [150, 150]
+  end
+
+  version :thumb_2x, from_version: :small do
     process resize_to_fit: [100, 100]
   end
 
-  version :thumb do
+  version :thumb, from_version: :thumb_2x do
     process resize_to_fit: [50, 50]
   end
 

--- a/app/views/partials/_menu.slim
+++ b/app/views/partials/_menu.slim
@@ -20,7 +20,7 @@ div class="top-bar"
             a href="#"
               .row
                 .header__profile__picture
-                  = retina_image_tag current_user, :avatar, :thumb
+                  = retina_image_tag current_user, :avatar, :small
                 .header__profile__name
                   = current_user.username
                   small.role =< "(#{current_user.role})"

--- a/db/migrate/20170527160712_remove_retina_dimensions_from_users.rb
+++ b/db/migrate/20170527160712_remove_retina_dimensions_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveRetinaDimensionsFromUsers < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :users, :retina_dimensions, :text
+  end
+end

--- a/db/migrate/20170527160724_remove_retina_dimensions_from_pictures.rb
+++ b/db/migrate/20170527160724_remove_retina_dimensions_from_pictures.rb
@@ -1,0 +1,5 @@
+class RemoveRetinaDimensionsFromPictures < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :pictures, :retina_dimensions, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,52 +10,52 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170226194724) do
+ActiveRecord::Schema.define(version: 20170527160724) do
 
   create_table "blogs", force: :cascade do |t|
-    t.string   "title"
-    t.string   "slug"
-    t.text     "content"
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
-    t.integer  "category_id"
-    t.integer  "user_id"
-    t.integer  "comments_count", default: 0, null: false
+    t.string "title"
+    t.string "slug"
+    t.text "content"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "category_id"
+    t.integer "user_id"
+    t.integer "comments_count", default: 0, null: false
     t.index ["category_id"], name: "index_blogs_on_category_id"
     t.index ["slug"], name: "index_blogs_on_slug"
     t.index ["user_id"], name: "index_blogs_on_user_id"
   end
 
   create_table "categories", force: :cascade do |t|
-    t.string   "name"
-    t.string   "slug"
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
-    t.integer  "blogs_count", default: 0, null: false
+    t.string "name"
+    t.string "slug"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "blogs_count", default: 0, null: false
     t.index ["slug"], name: "index_categories_on_slug", unique: true
   end
 
   create_table "comments", force: :cascade do |t|
-    t.string   "commentable_type"
-    t.integer  "commentable_id"
-    t.string   "title"
-    t.text     "body"
-    t.string   "subject"
-    t.integer  "lft"
-    t.integer  "rgt"
-    t.integer  "parent_id"
-    t.integer  "user_id"
-    t.datetime "created_at",       null: false
-    t.datetime "updated_at",       null: false
+    t.string "commentable_type"
+    t.integer "commentable_id"
+    t.string "title"
+    t.text "body"
+    t.string "subject"
+    t.integer "lft"
+    t.integer "rgt"
+    t.integer "parent_id"
+    t.integer "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["commentable_type", "commentable_id"], name: "index_comments_on_commentable_type_and_commentable_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "friendly_id_slugs", force: :cascade do |t|
-    t.string   "slug",                      null: false
-    t.integer  "sluggable_id",              null: false
-    t.string   "sluggable_type", limit: 50
-    t.string   "scope"
+    t.string "slug", null: false
+    t.integer "sluggable_id", null: false
+    t.string "sluggable_type", limit: 50
+    t.string "scope"
     t.datetime "created_at"
     t.index ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true
     t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type"
@@ -64,24 +64,23 @@ ActiveRecord::Schema.define(version: 20170226194724) do
   end
 
   create_table "pictures", force: :cascade do |t|
-    t.string   "attachable_type"
-    t.integer  "attachable_id"
-    t.string   "image"
-    t.text     "retina_dimensions"
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
+    t.string "attachable_type"
+    t.integer "attachable_id"
+    t.string "image"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["attachable_type", "attachable_id"], name: "index_pictures_on_attachable_type_and_attachable_id"
   end
 
   create_table "taggings", force: :cascade do |t|
-    t.integer  "tag_id"
-    t.string   "taggable_type"
-    t.integer  "taggable_id"
-    t.string   "tagger_type"
-    t.integer  "tagger_id"
-    t.string   "context",       limit: 128
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
+    t.integer "tag_id"
+    t.string "taggable_type"
+    t.integer "taggable_id"
+    t.string "tagger_type"
+    t.integer "tagger_id"
+    t.string "context", limit: 128
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["context"], name: "index_taggings_on_context"
     t.index ["tag_id"], name: "index_taggings_on_tag_id"
     t.index ["taggable_type", "taggable_id"], name: "index_taggings_on_taggable_type_and_taggable_id"
@@ -89,33 +88,32 @@ ActiveRecord::Schema.define(version: 20170226194724) do
   end
 
   create_table "tags", force: :cascade do |t|
-    t.string   "name"
-    t.integer  "taggings_count", default: 0
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
+    t.string "name"
+    t.integer "taggings_count", default: 0
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "email",                  default: "", null: false
-    t.string   "username",               default: "", null: false
-    t.string   "slug",                   default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
-    t.string   "reset_password_token"
+    t.string "email", default: "", null: false
+    t.string "username", default: "", null: false
+    t.string "slug", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
+    t.integer "sign_in_count", default: 0, null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string   "current_sign_in_ip"
-    t.string   "last_sign_in_ip"
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
-    t.integer  "role",                   default: 2
-    t.integer  "blogs_count",            default: 0,  null: false
-    t.string   "avatar"
-    t.text     "retina_dimensions"
-    t.integer  "comments_count",         default: 0,  null: false
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "role", default: 2
+    t.integer "blogs_count", default: 0, null: false
+    t.string "avatar"
+    t.integer "comments_count", default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["slug"], name: "index_users_on_slug"

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -14,6 +14,7 @@ if Rails.env.development?
       'exclude_fixtures'     => 'false',
       'exclude_factories'    => 'false',
       'exclude_scaffolds'    => 'true',
+      'exclude_serializers'  => 'true',
 
       'routes'               => 'false',
       'position_in_routes'   => 'after',

--- a/spec/factories/pictures.rb
+++ b/spec/factories/pictures.rb
@@ -12,13 +12,12 @@ end
 #
 # Table name: pictures
 #
-#  id                :integer          not null, primary key
-#  attachable_type   :string
-#  attachable_id     :integer
-#  image             :string
-#  retina_dimensions :text
-#  created_at        :datetime         not null
-#  updated_at        :datetime         not null
+#  id              :integer          not null, primary key
+#  attachable_type :string
+#  attachable_id   :integer
+#  image           :string
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
 #
 # Indexes
 #

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -41,7 +41,6 @@ end
 #  role                   :integer          default("author")
 #  blogs_count            :integer          default(0), not null
 #  avatar                 :string
-#  retina_dimensions      :text
 #  comments_count         :integer          default(0), not null
 #
 # Indexes

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -2,12 +2,16 @@ require 'rails_helper'
 
 describe ApplicationHelper do
   describe '#website_conf' do
-    it 'returns same object' do
-      expect(website_conf).to eq Rails.configuration.website
-    end
+    subject { website_conf }
 
-    it 'has correct keys' do
-      expect(website_conf).to include('title')
-    end
+    it { is_expected.to eq Rails.configuration.website }
+    it { is_expected.to include('title') }
+  end
+
+  describe '#retina_image_tag' do
+    let!(:picture) { create(:picture, :for_blog) }
+    subject { retina_image_tag(picture, :image, :large) }
+
+    it { is_expected.to eq '<img srcset="/uploads/picture/1/large_2x_image.jpg 2x" src="/uploads/picture/1/large_image.jpg" alt="Large image" />' }
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,6 +14,9 @@ Dir[Rails.root.join('spec', 'features', 'shared_examples', '**', '*.rb')].each d
   require f
 end
 
+ActiveRecord::Migration.check_pending!
+ActiveRecord::Migration.maintain_test_schema!
+
 RSpec.configure do |config|
   config.extend ControllerMacros, type: :controller
   config.include AbstractController::Translation
@@ -22,9 +25,6 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = false
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!
-
-  ActiveRecord::Migration.check_pending!
-  ActiveRecord::Migration.maintain_test_schema!
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/uploaders/avatar_uploader_spec.rb
+++ b/spec/uploaders/avatar_uploader_spec.rb
@@ -17,27 +17,23 @@ describe AvatarUploader do
     uploader.remove!
   end
 
-  context 'the thumb version' do
-    it 'scales down a landscape image to be exactly 50 by 50 pixels (x2 for retina display)' do
-      expect(uploader.thumb).to have_dimensions(50 * 2, 50 * 2)
-    end
-  end
-
   context 'the small version' do
-    it 'scales down a landscape image to fit within 100 by 100 pixels (x2 for retina display)' do
-      expect(uploader.small).to have_dimensions(100 * 2, 100 * 2)
+    it 'scales down avatar to fill within 100 by 100 pixels' do
+      expect(uploader.small).to have_dimensions(100, 100)
     end
-  end
 
-  context 'the medium version' do
-    it 'scales down a landscape image to fit within 200 by 200 pixels (x2 for retina display)' do
-      expect(uploader.medium).to have_dimensions(200 * 2, 200 * 2)
+    it 'scales down avatar to fill within 200 by 200 pixels (retina)' do
+      expect(uploader.small_2x).to have_dimensions(200, 200)
     end
   end
 
   context 'the large version' do
-    it 'scales down a landscape image to fit within 400 by 400 pixels (x2 for retina display)' do
-      expect(uploader.large).to have_dimensions(400 * 2, 400 * 2)
+    it 'scales down avatar to fill within 200 by 200 pixels' do
+      expect(uploader.large).to have_dimensions(200, 200)
+    end
+
+    it 'scales down avatar to fill within 400 by 400 pixels (retina)' do
+      expect(uploader.large_2x).to have_dimensions(400, 400)
     end
   end
 

--- a/spec/uploaders/image_uploader_spec.rb
+++ b/spec/uploaders/image_uploader_spec.rb
@@ -18,26 +18,42 @@ describe ImageUploader do
   end
 
   context 'the thumb version' do
-    it 'scales down a landscape image to be exactly 50 by 50 pixels (x2 for retina display)' do
-      expect(uploader.thumb).to have_dimensions(50 * 2, 50 * 2)
+    it 'scales down a picture to fit within 50 by 50 pixels' do
+      expect(uploader.thumb).to have_dimensions(50, 50)
+    end
+
+    it 'scales down a picture to fit within 100 by 100 pixels (retina)' do
+      expect(uploader.thumb_2x).to have_dimensions(100, 100)
     end
   end
 
   context 'the small version' do
-    it 'scales down a landscape image to fit within 100 by 100 pixels (x2 for retina display)' do
-      expect(uploader.small).to have_dimensions(100 * 2, 100 * 2)
+    it 'scales down a picture to fit within 150 by 150 pixels' do
+      expect(uploader.small).to have_dimensions(150, 150)
+    end
+
+    it 'scales down a picture to fit within 300 by 300 pixels (retina)' do
+      expect(uploader.small_2x).to have_dimensions(300, 300)
     end
   end
 
   context 'the medium version' do
-    it 'scales down a landscape image to fit within 256 by 256 pixels (x2 for retina display)' do
-      expect(uploader.medium).to have_dimensions(256 * 2, 256 * 2)
+    it 'scales down a picture to fit within 300 by 300 pixels' do
+      expect(uploader.medium).to have_dimensions(300, 300)
+    end
+
+    it 'scales down a picture to fit within 600 by 600 pixels (retina)' do
+      expect(uploader.medium_2x).to have_dimensions(600, 600)
     end
   end
 
   context 'the large version' do
-    it 'scales down a landscape image to fit within 512 by 512 pixels (x2 for retina display)' do
-      expect(uploader.large).to have_dimensions(512 * 2, 512 * 2)
+    it 'scales down a picture to fit within 600 by 600 pixels' do
+      expect(uploader.large).to have_dimensions(600, 600)
+    end
+
+    it 'scales down a picture to fit within 1200 by 1200 pixels (retina)' do
+      expect(uploader.large_2x).to have_dimensions(1200, 1200)
     end
   end
 


### PR DESCRIPTION
As the `retina_rails` gem hasn't been released for a loooong time, I decided to drop this dependency from the project and to implement my own code with `carrierwave` (inspired by this [post](http://www.terracoding.com/blog/retina-carrierwave-images/)).

**Details**
- REMOVE `retina_rails` gem
- REMOVE `retina_dimensions` column from `User` and `Picture` models
- SETUP a `retina_image_tag` helper method using `srcset` attribute
- RENAME `picture_uploader_spec` to `image_uploader_spec`
- FIX broken specs