### PR TITLE
SETUP a 'gitattributes' file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,24 @@
+# Define the line ending behavior of the different file extensions
+# Set default behaviour, in case users don't have core.autocrlf set.
+* text=auto
+* text eol=lf
+
+#
+# Ignore while exporting
+# ========================
+/lib export-ignore
+/bin/procfile export-ignore
+/spec export-ignore
+
+.eslintignore export-ignore
+.eslintrc.yml export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.pryrc export-ignore
+.rspec export-ignore
+.rubocop.yml export-ignore
+.sass-lint.yml export-ignore
+.simplecov export-ignore
+.travis.yml export-ignore
+Procfile export-ignore
+README.md export-ignore


### PR DESCRIPTION
Some files are not necessary when deploying a project and takes space for nothing. Specifying them into a `gitattributes` file allow to exclude them.

**Details**
- CREATE `gitattributes` file
- EXCLUDE unnecessary files and folders