### PR TITLE
DISPLAY minimal `webpack` stats

### DIFF
--- a/app/javascript/sass/_foundation.sass
+++ b/app/javascript/sass/_foundation.sass
@@ -18,7 +18,7 @@
 @include foundation-drilldown-menu
 @include foundation-dropdown
 @include foundation-dropdown-menu
-@include foundation-flex-video
+@include foundation-responsive-embed
 @include foundation-label
 @include foundation-media-object
 @include foundation-menu

--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -27,6 +27,7 @@ module.exports = merge(sharedConfig, {
     historyApiFallback: true,
     watchOptions: {
       ignored: /node_modules/
-    }
+    },
+    stats: 'minimal'
   }
 })


### PR DESCRIPTION
**Details**
- ADD `stats: 'minimal'` to webpack devServer config
- FIX `foundation` deprecation warning