### PR TITLE
FIX broken sourcemaps in development

### DIFF
--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -5,7 +5,7 @@ const sharedConfig = require('./shared.js')
 const { settings, output } = require('./configuration.js')
 
 module.exports = merge(sharedConfig, {
-  devtool: 'cheap-eval-source-map',
+  devtool: 'inline-source-map',
   output: {
     pathinfo: true
   },

--- a/config/webpack/loaders/sass.js
+++ b/config/webpack/loaders/sass.js
@@ -9,7 +9,8 @@ module.exports = {
       {
         loader: 'css-loader',
         options: {
-          minimize: env.NODE_ENV === 'production' || env.NODE_ENV === 'staging'
+          minimize: env.NODE_ENV === 'production' || env.NODE_ENV === 'staging',
+          sourceMap: true
         }
       },
       {


### PR DESCRIPTION
**Details**
- ENABLE `sourcemaps` for `css-loader`
- USE `inline-source-map` config for `devtool` option