### PR TITLE
DISABLE sourcemaps in production

### DIFF
--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -1,3 +1,6 @@
 const environment = require('./environment')
 
-module.exports = environment.toWebpackConfig()
+const config = environment.toWebpackConfig()
+config.devtool = 'none'
+
+module.exports = config


### PR DESCRIPTION
This option is useful in development but not needed in production. It also
make the build slower and expose these informations to everyone.

Details:
- SET `devtool` option to false in webpacker production configuration