### PR TITLE
LOAD resource with cancancan

### DIFF
--- a/app/controllers/admin/blogs_controller.rb
+++ b/app/controllers/admin/blogs_controller.rb
@@ -1,13 +1,13 @@
 module Admin
   class BlogsController < AdminController
-    before_action :set_blog, only: %i[edit update destroy]
-    before_action :set_form, only: %i[new create edit update]
+    load_and_authorize_resource
 
-    authorize_resource
+    before_action :set_form,
+      only: %i[new create edit update]
 
     # GET /admin/blogs
     def index
-      @blogs = Blog.with_includes.order_desc.page params[:page]
+      @blogs = @blogs.with_includes.order_desc.page params[:page]
     end
 
     # GET /admin/blogs/new
@@ -41,13 +41,8 @@ module Admin
 
     private
 
-    def set_blog
-      @blog = Blog.includes(:user).friendly.find(params[:id])
-    end
-
     def set_form
-      object = @blog.nil? ? current_user.blogs.new : @blog
-      @form = BlogForm.new(object)
+      @form = BlogForm.new(@blog.new_record? ? current_user.blogs.new : @blog)
     end
 
     def save_action(action)

--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -1,14 +1,15 @@
 module Admin
   class CategoriesController < AdminController
-    before_action :set_category, only: %i[edit update destroy]
-    before_action :set_form, only: %i[new create edit update]
+    load_and_authorize_resource
 
-    authorize_resource
+    before_action :set_form,
+      only: %i[new create edit update]
+
     add_breadcrumb I18n.t('categories.index.title'), :admin_categories_path
 
     # GET /admin/categories
     def index
-      @categories = Category.all.page params[:page]
+      @categories = @categories.page params[:page]
     end
 
     # GET /admin/categories/new
@@ -40,14 +41,8 @@ module Admin
 
     private
 
-    # Use callbacks to share common setup or constraints between actions.
-    def set_category
-      @category = Category.friendly.find(params[:id])
-    end
-
     def set_form
-      object = @category.nil? ? Category.new : @category
-      @form = CategoryForm.new(object)
+      @form = CategoryForm.new(@category || Category.new)
     end
 
     def save_action(action)

--- a/app/controllers/categories/blogs_controller.rb
+++ b/app/controllers/categories/blogs_controller.rb
@@ -2,11 +2,8 @@ module Categories
   class BlogsController < ApplicationController
     include Blogs::Sidebarable
 
-    load_resource :category,
-      find_by: :slug
-    load_resource :blog,
-      find_by: :slug,
-      through: :category
+    load_resource :category
+    load_and_authorize_resource through: :category
 
     add_breadcrumb I18n.t('blogs.index.title'), :blogs_path
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,5 +22,8 @@ module BlogMVC
 
     # Website settings
     config.website = config_for(:website)
+
+    # Disable strong parameters to make Reform play nicely with Cancancan
+    config.action_controller.permit_all_parameters = true
   end
 end

--- a/config/initializers/cancancan.rb
+++ b/config/initializers/cancancan.rb
@@ -1,0 +1,23 @@
+if defined?(CanCan)
+  class Object
+    def metaclass
+      class << self; self; end
+    end
+  end
+
+  module CanCan
+    module ModelAdapters
+      class ActiveRecord4Adapter < AbstractAdapter
+        @@friendly_support = {}
+
+        def self.find(model_class, id)
+          klass =
+          model_class.metaclass.ancestors.include?(ActiveRecord::Associations::CollectionProxy) ?
+            model_class.klass : model_class
+          @@friendly_support[klass] ||= klass.metaclass.ancestors.include?(FriendlyId)
+          @@friendly_support[klass] == true ? model_class.friendly.find(id) : model_class.find(id)
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/admin/categories_controller_spec.rb
+++ b/spec/controllers/admin/categories_controller_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Admin::CategoriesController do
         format: format
     end
 
-    let(:attributes) { valid_attributes }
+    let(:attributes) { valid_attributes[:category] }
 
     it_behaves_like :not_logged_in
 


### PR DESCRIPTION
`cancancan` make it very easier to load and authorize controller actions.
Currently, only the autorization resource is handled, so we should use it
to load as well.

Details:
- ADD initializer to patch `cancancan` with `friendly_id`
- REPLACE old `before_action` by `load_resource` (cancancan style !)