### PR TITLE
ADD flash_message shared examples

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,3 +8,7 @@ inherit_from:
 AllCops:
   TargetRubyVersion: 2.4
   TargetRailsVersion: 5.1
+
+RSpec/NamedSubject:
+  Exclude:
+    - spec/features/shared_examples/*.rb

--- a/config/locales/comments/create.fr.yml
+++ b/config/locales/comments/create.fr.yml
@@ -1,5 +1,5 @@
 fr:
   comments:
-    destroy:
-      success: Votre commentaire a bien été supprimé
-      alert: Votre commentaire n'a pas pu être supprimé
+    create:
+      success: Votre commentaire a été ajouté avec succès
+      alert: Votre commentaire n'a pas pu être ajouté

--- a/config/locales/comments/destroy.fr.yml
+++ b/config/locales/comments/destroy.fr.yml
@@ -1,5 +1,5 @@
 fr:
   comments:
-    create:
-      success: Votre commentaire a été ajouté avec succès
-      alert: Votre commentaire n'a pas pu être ajouté
+    destroy:
+      success: Votre commentaire a bien été supprimé
+      alert: Votre commentaire n'a pas pu être supprimé

--- a/spec/controllers/admin/blogs_controller_spec.rb
+++ b/spec/controllers/admin/blogs_controller_spec.rb
@@ -29,9 +29,7 @@ RSpec.describe Admin::BlogsController do
   describe 'GET #new' do
     subject { get :new, format: format }
 
-    context 'when not logged in' do
-      it_behaves_like :not_logged_in
-    end
+    it_behaves_like :not_logged_in
 
     context 'as author' do
       let(:user) { create(:user, :author) }
@@ -56,7 +54,7 @@ RSpec.describe Admin::BlogsController do
   end
 
   describe 'POST #create' do
-    subject(:create_blog) do
+    subject do
       post :create,
         params: { blog: attributes },
         format: format
@@ -64,9 +62,7 @@ RSpec.describe Admin::BlogsController do
 
     let(:attributes) { valid_attributes[:blog] }
 
-    context 'when not logged in' do
-      it_behaves_like :not_logged_in
-    end
+    it_behaves_like :not_logged_in
 
     context 'as author' do
       let(:user) { create(:user, :author) }
@@ -125,9 +121,7 @@ RSpec.describe Admin::BlogsController do
         format: format
     end
 
-    context 'when not logged in' do
-      it_behaves_like :not_logged_in
-    end
+    it_behaves_like :not_logged_in
 
     context 'as author' do
       let(:user) { create(:user, :author) }
@@ -138,6 +132,8 @@ RSpec.describe Admin::BlogsController do
 
     context 'as admin' do
       let(:user) { create(:user, :admin) }
+      let(:flash_type) { 'alert' }
+      let(:flash_message) { "Vous n'êtes pas autorisé à modifier cet article de Blog" }
 
       it { is_expected.to have_http_status(200) }
       it { is_expected.to render_template :edit }
@@ -145,7 +141,7 @@ RSpec.describe Admin::BlogsController do
       context 'when try to access a master' do
         let(:blog) { create(:blog, user: create(:user, :master)) }
 
-        it_behaves_like :unauthorized, I18n.t('unauthorized.update.blog')
+        it_behaves_like :unauthorized
       end
     end
 
@@ -158,7 +154,7 @@ RSpec.describe Admin::BlogsController do
   end
 
   describe 'PATCH #update' do
-    subject(:update_blog) do
+    subject do
       patch :update,
         params: { id: blog, blog: attributes },
         format: format
@@ -166,9 +162,7 @@ RSpec.describe Admin::BlogsController do
 
     let(:attributes) { valid_attributes[:blog].merge!(title: 'FooBar update') }
 
-    context 'when not logged in' do
-      it_behaves_like :not_logged_in
-    end
+    it_behaves_like :not_logged_in
 
     context 'as author' do
       let(:user) { create(:user, :author) }
@@ -194,8 +188,10 @@ RSpec.describe Admin::BlogsController do
       context 'when try to access a master' do
         let(:blog) { create(:blog, user: create(:user, :master)) }
         let(:attributes) { blog.category }
+        let(:flash_type) { 'alert' }
+        let(:flash_message) { "Vous n'êtes pas autorisé à modifier cet article de Blog" }
 
-        it_behaves_like :unauthorized, I18n.t('unauthorized.update.blog')
+        it_behaves_like :unauthorized
       end
     end
 
@@ -218,25 +214,13 @@ RSpec.describe Admin::BlogsController do
   end
 
   describe 'DELETE #destroy' do
-    subject(:destroy_blog) do
+    subject do
       delete :destroy,
         params: { id: blog },
         format: format
     end
 
-    context 'when not logged in' do
-      it_behaves_like :not_logged_in
-    end
-
-    context 'any user' do
-      let(:user) { create(:user, :admin) }
-
-      before { create_list(:comment, 4, commentable: blog, user: user) }
-
-      it 'destroys comments linked' do
-        expect { destroy_blog }.to change(Comment, :count).by(-4)
-      end
-    end
+    it_behaves_like :not_logged_in
 
     context 'as author' do
       let!(:blog) { create(:blog, :author) }
@@ -256,8 +240,10 @@ RSpec.describe Admin::BlogsController do
 
       context 'when try to access a master' do
         let(:blog) { create(:blog, :master) }
+        let(:flash_type) { 'alert' }
+        let(:flash_message) { "Vous n'êtes pas autorisé à supprimer cet article de Blog" }
 
-        it_behaves_like :unauthorized, I18n.t('unauthorized.destroy.blog')
+        it_behaves_like :unauthorized
       end
     end
 

--- a/spec/controllers/admin/categories_controller_spec.rb
+++ b/spec/controllers/admin/categories_controller_spec.rb
@@ -16,14 +16,14 @@ RSpec.describe Admin::CategoriesController do
   describe 'GET #index' do
     subject { get :index, format: format }
 
-    context 'when not logged in' do
-      it_behaves_like :not_logged_in
-    end
+    it_behaves_like :not_logged_in
 
     context 'as author' do
       let(:user) { create(:user, :author) }
+      let(:flash_type) { 'alert' }
+      let(:flash_message) { "Vous n'êtes pas autorisé à accéder à cette page" }
 
-      it_behaves_like :unauthorized, I18n.t('unauthorized.read.category')
+      it_behaves_like :unauthorized
     end
 
     context 'as admin' do
@@ -44,14 +44,14 @@ RSpec.describe Admin::CategoriesController do
   describe 'GET #new' do
     subject { get :new, format: format }
 
-    context 'when not logged in' do
-      it_behaves_like :not_logged_in
-    end
+    it_behaves_like :not_logged_in
 
     context 'as author' do
       let(:user) { create(:user, :author) }
+      let(:flash_type) { 'alert' }
+      let(:flash_message) { "Vous n'êtes pas autorisé à gérer cette ressource" }
 
-      it_behaves_like :unauthorized, I18n.t('unauthorized.manage.all')
+      it_behaves_like :unauthorized
     end
 
     context 'as admin' do
@@ -78,15 +78,7 @@ RSpec.describe Admin::CategoriesController do
 
     let(:attributes) { valid_attributes }
 
-    context 'when not logged in' do
-      it_behaves_like :not_logged_in
-
-      it_behaves_like :unauthorized, I18n.t('unauthorized.manage.all')
-
-      it 'does not create a record' do
-        expect { create_category }.to_not change(Category, :count)
-      end
-    end
+    it_behaves_like :not_logged_in
 
     context 'as author' do
       let(:user) { create(:user, :author) }
@@ -141,14 +133,14 @@ RSpec.describe Admin::CategoriesController do
         format: format
     end
 
-    context 'when not logged in' do
-      it_behaves_like :not_logged_in
-    end
+    it_behaves_like :not_logged_in
 
     context 'as author' do
       let(:user) { create(:user, :author) }
+      let(:flash_type) { 'alert' }
+      let(:flash_message) { "Vous n'êtes pas autorisé à gérer cette ressource" }
 
-      it_behaves_like :unauthorized, I18n.t('unauthorized.manage.all')
+      it_behaves_like :unauthorized
     end
 
     context 'as admin' do
@@ -167,7 +159,7 @@ RSpec.describe Admin::CategoriesController do
   end
 
   describe 'PATCH #update' do
-    subject(:update_category) do
+    subject do
       patch :update,
         params: { id: category, category: attributes },
         format: format
@@ -175,14 +167,14 @@ RSpec.describe Admin::CategoriesController do
 
     let(:attributes) { valid_attributes[:category].merge!(name: 'FooBar update') }
 
-    context 'when not logged in' do
-      it_behaves_like :not_logged_in
-    end
+    it_behaves_like :not_logged_in
 
     context 'as author' do
       let(:user) { create(:user, :author) }
+      let(:flash_type) { 'alert' }
+      let(:flash_message) { "Vous n'êtes pas autorisé à gérer cette ressource" }
 
-      it_behaves_like :unauthorized, I18n.t('unauthorized.manage.all')
+      it_behaves_like :unauthorized
     end
 
     context 'as admin' do
@@ -225,14 +217,14 @@ RSpec.describe Admin::CategoriesController do
         format: format
     end
 
-    context 'when not logged in' do
-      it_behaves_like :not_logged_in
-    end
+    it_behaves_like :not_logged_in
 
     context 'as author' do
       let(:user) { create(:user, :author) }
+      let(:flash_type) { 'alert' }
+      let(:flash_message) { "Vous n'êtes pas autorisé à gérer cette ressource" }
 
-      it_behaves_like :unauthorized, I18n.t('unauthorized.manage.all')
+      it_behaves_like :unauthorized
 
       it 'does not destroy a category' do
         expect { destroy_category }.to_not change(Category, :count)

--- a/spec/controllers/admin/dashboards_controller_spec.rb
+++ b/spec/controllers/admin/dashboards_controller_spec.rb
@@ -7,22 +7,9 @@ RSpec.describe Admin::DashboardsController do
   before { login_user user }
 
   describe 'GET #show' do
-    subject(:show) { get :show, format: format }
+    subject { get :show, format: format }
 
-    context 'when not logged in' do
-      it_behaves_like :not_logged_in
-
-      describe 'flash message' do
-        before do
-          sign_out user
-          show
-        end
-
-        it 'has correct message' do
-          expect(flash[:alert]).to eq 'Vous devez vous connecter ou vous inscrire pour continuer.'
-        end
-      end
-    end
+    it_behaves_like :not_logged_in
 
     context 'when logged in' do
       it { is_expected.to have_http_status(200) }

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe CommentsController do
   before { login_user user }
 
   describe 'POST #create' do
-    subject(:create_comment) do
+    subject do
       post :create,
         params: { blog_id: blog, comment: attributes },
         format: format
@@ -68,7 +68,7 @@ RSpec.describe CommentsController do
   end
 
   describe 'DELETE #destroy' do
-    subject(:destroy_comment) do
+    subject do
       delete :destroy,
         params: { blog_id: blog, id: comment },
         format: format
@@ -76,25 +76,21 @@ RSpec.describe CommentsController do
 
     let!(:comment) { create(:comment, commentable: blog, user: user) }
 
-    context 'when not logged in' do
-      it_behaves_like :not_logged_in
+    it_behaves_like :not_logged_in
+
+    context 'with HTML format' do
+      let(:format) { :html }
+
+      it_behaves_like :comment_destroyable
     end
 
-    context 'when logged in' do
-      context 'with HTML format' do
-        let(:format) { :html }
+    context 'with JS format' do
+      let(:format) { :js }
 
-        it_behaves_like :comment_destroyable
-      end
+      it { is_expected.to have_http_status(200) }
+      it { is_expected.to render_template :destroy }
 
-      context 'with JS format' do
-        let(:format) { :js }
-
-        it { is_expected.to have_http_status(200) }
-        it { is_expected.to render_template :destroy }
-
-        it_behaves_like :comment_destroyable
-      end
+      it_behaves_like :comment_destroyable
     end
   end
 end

--- a/spec/controllers/contacts_controller_spec.rb
+++ b/spec/controllers/contacts_controller_spec.rb
@@ -33,6 +33,10 @@ RSpec.describe ContactsController do
     after { ActionMailer::Base.deliveries.clear }
 
     context 'valid attributes' do
+      let(:flash_type) { 'notice' }
+      let(:flash_message) { 'Votre email a bien été envoyé.' }
+
+      it_behaves_like :flash_message
       it { is_expected.to have_http_status(302) }
       it { is_expected.to redirect_to new_contact_url }
 
@@ -47,14 +51,6 @@ RSpec.describe ContactsController do
 
         it 'sends two emails' do
           expect { create_contact }.to change { ActionMailer::Base.deliveries.count }.by(2)
-        end
-      end
-
-      describe 'flash message' do
-        before { create_contact }
-
-        it 'has correct message' do
-          expect(controller).to set_flash[:notice].to t('contacts.create.notice')
         end
       end
     end

--- a/spec/features/shared_examples/blogs.rb
+++ b/spec/features/shared_examples/blogs.rb
@@ -1,6 +1,8 @@
-# Blogs Creatable
-#
 RSpec.shared_examples_for :blog_creatable do
+  let(:flash_type) { 'notice' }
+  let(:flash_message) { "L'article de Blog a été créé avec succès" }
+
+  it_behaves_like :flash_message
   it { is_expected.to have_http_status(302) }
 
   it do
@@ -8,29 +10,23 @@ RSpec.shared_examples_for :blog_creatable do
   end
 
   it 'creates a record' do
-    expect { create_blog }.to change(Blog, :count).by(1)
+    expect { subject }.to change(Blog, :count).by(1)
   end
 
   describe 'owner' do
-    before { create_blog }
+    before { subject }
 
     it 'has correct owner' do
       expect(assigns(:form).model.user).to eq(user)
     end
   end
-
-  describe 'flash message' do
-    before { create_blog }
-
-    it 'has correct message' do
-      expect(controller).to set_flash[:notice].to t('admin.blogs.create.notice')
-    end
-  end
 end
 
-# Blogs Updatable
-#
 RSpec.shared_examples_for :blog_updatable do
+  let(:flash_type) { 'notice' }
+  let(:flash_message) { "L'article de Blog a été mis à jour avec succès" }
+
+  it_behaves_like :flash_message
   it { is_expected.to have_http_status(302) }
 
   it do
@@ -38,37 +34,33 @@ RSpec.shared_examples_for :blog_updatable do
   end
 
   describe 'values' do
-    before { update_blog }
+    before { subject }
 
     it 'changes name' do
       expect(assigns(:form).model.title).to eq 'FooBar update'
     end
   end
-
-  describe 'flash message' do
-    before { update_blog }
-
-    it 'has correct message' do
-      expect(controller).to set_flash[:notice].to t('admin.blogs.update.notice')
-    end
-  end
 end
 
-# Blogs Destroyable
-#
 RSpec.shared_examples_for :blog_destroyable do
+  before do
+    create_list :comment, 4,
+      commentable: blog,
+      user: user
+  end
+
+  let(:flash_type) { 'notice' }
+  let(:flash_message) { "L'article de Blog a été supprimé avec succès" }
+
+  it_behaves_like :flash_message
   it { is_expected.to have_http_status(302) }
   it { is_expected.to redirect_to blogs_url }
 
   it 'destroys a blog' do
-    expect { destroy_blog }.to change(Blog, :count).by(-1)
+    expect { subject }.to change(Blog, :count).by(-1)
   end
 
-  describe 'flash message' do
-    before { destroy_blog }
-
-    it 'has correct message' do
-      expect(controller).to set_flash[:notice].to t('admin.blogs.destroy.notice')
-    end
+  it 'destroys comments linked' do
+    expect { subject }.to change(Comment, :count).by(-4)
   end
 end

--- a/spec/features/shared_examples/categories.rb
+++ b/spec/features/shared_examples/categories.rb
@@ -1,38 +1,26 @@
-# Categories Creatable
-#
 RSpec.shared_examples_for :category_creatable do
+  let(:flash_type) { 'notice' }
+  let(:flash_message) { 'La Catégorie a été créée avec succès' }
+
+  it_behaves_like :flash_message
   it { is_expected.to have_http_status(302) }
   it { is_expected.to redirect_to admin_categories_url }
 
   it 'creates a record' do
-    expect { create_category }.to change(Category, :count).by(1)
-  end
-
-  describe 'flash message' do
-    before { create_category }
-
-    it 'has correct message' do
-      expect(controller).to set_flash[:notice].to t('admin.categories.create.notice')
-    end
+    expect { subject }.to change(Category, :count).by(1)
   end
 end
 
-# Categories Updatable
-#
 RSpec.shared_examples_for :category_updatable do
+  let(:flash_type) { 'notice' }
+  let(:flash_message) { 'La Catégorie a été modifiée avec succès' }
+
+  it_behaves_like :flash_message
   it { is_expected.to have_http_status(302) }
   it { is_expected.to redirect_to admin_categories_url }
 
-  describe 'flash message' do
-    before { update_category }
-
-    it 'has correct message' do
-      expect(controller).to set_flash[:notice].to t('admin.categories.update.notice')
-    end
-  end
-
   describe 'values' do
-    before { update_category }
+    before { subject }
 
     it 'changes name' do
       expect(assigns(:category).name).to eq 'FooBar update'
@@ -40,25 +28,19 @@ RSpec.shared_examples_for :category_updatable do
   end
 end
 
-# Categories Destroyable
-#
 RSpec.shared_examples_for :category_destroyable do
+  let(:flash_type) { 'notice' }
+  let(:flash_message) { 'La Catégorie a été supprimée avec succès' }
+
+  it_behaves_like :flash_message
   it { is_expected.to have_http_status(302) }
   it { is_expected.to redirect_to admin_categories_url }
 
-  describe 'flash message' do
-    before { destroy_category }
-
-    it 'has correct message' do
-      expect(controller).to set_flash[:notice].to t('admin.categories.destroy.notice')
-    end
-  end
-
   it 'destroys a category' do
-    expect { destroy_category }.to change(Category, :count).by(-1)
+    expect { subject }.to change(Category, :count).by(-1)
   end
 
   it 'destroys associated blogs' do
-    expect { destroy_category }.to change(category.blogs, :count).by(-3)
+    expect { subject }.to change(category.blogs, :count).by(-3)
   end
 end

--- a/spec/features/shared_examples/comments.rb
+++ b/spec/features/shared_examples/comments.rb
@@ -1,65 +1,48 @@
-# Comments Creatable
-#
 RSpec.shared_examples_for :comment_creatable do
+  let(:flash_type) { 'success' }
+  let(:flash_message) { 'Votre commentaire a été ajouté avec succès' }
+
+  it_behaves_like :flash_message
   it { is_expected.to have_http_status(302) }
   it do
     is_expected.to redirect_to category_blog_url(blog.category, blog)
   end
 
   it 'creates a new comment' do
-    expect { create_comment }.to change(Comment, :count).by(1)
+    expect { subject }.to change(Comment, :count).by(1)
   end
 
   describe 'owner' do
-    before { create_comment }
+    before { subject }
 
     it 'has correct owner' do
       expect(assigns(:comment).user).to eq(user)
     end
   end
-
-  describe 'flash message' do
-    before { create_comment }
-
-    it 'has correct message' do
-      expect(controller).to set_flash[:success].to(t('comments.create.success'))
-    end
-  end
 end
 
-# Comments not Creatable
-#
 RSpec.shared_examples_for :comment_not_creatable do
+  let(:flash_type) { 'alert' }
+  let(:flash_message) { "Votre commentaire n'a pas pu être ajouté" }
+
+  it_behaves_like :flash_message
   it { is_expected.to have_http_status(302) }
   it do
     is_expected.to redirect_to category_blog_url(blog.category, blog)
   end
 
   it 'does not create a new comment' do
-    expect { create_comment }.to_not change(Comment, :count)
-  end
-
-  describe 'flash message' do
-    before { create_comment }
-
-    it 'has correct message' do
-      expect(controller).to set_flash[:alert].to(t('comments.create.alert'))
-    end
+    expect { subject }.to_not change(Comment, :count)
   end
 end
 
-# Comments Destroyable
-#
 RSpec.shared_examples_for :comment_destroyable do
+  let(:flash_type) { 'success' }
+  let(:flash_message) { 'Votre commentaire a bien été supprimé' }
+
+  it_behaves_like :flash_message
+
   it 'destroys a comment' do
-    expect { destroy_comment }.to change(Comment, :count).by(-1)
-  end
-
-  describe 'flash message' do
-    before { destroy_comment }
-
-    it 'has correct message' do
-      expect(controller).to set_flash[:success].to(t('comments.destroy.success'))
-    end
+    expect { subject }.to change(Comment, :count).by(-1)
   end
 end

--- a/spec/features/shared_examples/flash_message.rb
+++ b/spec/features/shared_examples/flash_message.rb
@@ -1,0 +1,7 @@
+RSpec.shared_examples_for :flash_message do
+  before { subject }
+
+  it 'has correct message' do
+    expect(flash[flash_type]).to eq flash_message
+  end
+end

--- a/spec/features/shared_examples/not_logged_in.rb
+++ b/spec/features/shared_examples/not_logged_in.rb
@@ -3,9 +3,13 @@ RSpec.shared_examples_for :not_logged_in do |js: true|
 
   context 'with HTML format' do
     let(:format) { :html }
+    let(:flash_type) { 'alert' }
+    let(:flash_message) { 'Vous devez vous connecter ou vous inscrire pour continuer.' }
 
     it { is_expected.to have_http_status(302) }
     it { is_expected.to redirect_to new_user_session_path }
+
+    it_behaves_like :flash_message
   end
 
   if js

--- a/spec/features/shared_examples/unauthorized.rb
+++ b/spec/features/shared_examples/unauthorized.rb
@@ -1,12 +1,6 @@
-# rubocop:disable RSpec/NamedSubject
-
-RSpec.shared_examples_for :unauthorized do |message|
+RSpec.shared_examples_for :unauthorized do
   it { is_expected.to have_http_status(302) }
   it { is_expected.to redirect_to root_url }
 
-  describe 'flash message' do
-    before { subject }
-
-    it { expect(controller).to set_flash[:alert].to message }
-  end
+  it_behaves_like :flash_message
 end

--- a/spec/models/abilities/blog_abilities_spec.rb
+++ b/spec/models/abilities/blog_abilities_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Blog do
-  subject(:ability) { Ability.new(user) }
+  subject { Ability.new(user) }
 
   let(:user) { nil }
 

--- a/spec/models/abilities/category_abilities_spec.rb
+++ b/spec/models/abilities/category_abilities_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Category do
-  subject(:ability) { Ability.new(user) }
+  subject { Ability.new(user) }
 
   let(:user) { nil }
   let(:category) { create(:category) }

--- a/spec/models/abilities/comment_abilities_spec.rb
+++ b/spec/models/abilities/comment_abilities_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Comment do
-  subject(:ability) { Ability.new(user) }
+  subject { Ability.new(user) }
 
   let(:user) { nil }
   let(:comment) { create(:comment, user: user) }

--- a/spec/models/abilities/user_abilities_spec.rb
+++ b/spec/models/abilities/user_abilities_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe User do
-  subject(:ability) { Ability.new(user) }
+  subject { Ability.new(user) }
 
   let(:user) { nil }
 


### PR DESCRIPTION
Asserting `flash message` is needed in many differents controllers.
Instead of repeating the same code everytime, it is better to extract
it inside a `shared_example` context.

Details:
- FIX inversion with two i18n locales files
- EXTRACT all specs about flash inside `flash_message` shared examples
- IGNORE `subject` offense in shared examples