### PR TITLE
CREATE rspec mailers shared examples

### DIFF
--- a/spec/features/shared_examples/mailers.rb
+++ b/spec/features/shared_examples/mailers.rb
@@ -1,0 +1,17 @@
+RSpec.shared_examples_for :email_with_headers do
+  it 'renders the sender email' do
+    expect(email.from).to eq from
+  end
+
+  it 'renders the receiver email' do
+    expect(email.to).to eq to
+  end
+
+  it 'renders the subject' do
+    expect(email.subject).to eq subject
+  end
+
+  it 'renders the body' do
+    expect(email.body.encoded).to match body
+  end
+end

--- a/spec/mailers/contact_mailer_spec.rb
+++ b/spec/mailers/contact_mailer_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ContactMailer do
+  let(:attributes) { valid_attributes[:contact] }
   let(:valid_attributes) do
     { contact: { name: 'John Doe',
                  email: 'johndoe@test.fr',
@@ -13,44 +14,22 @@ RSpec.describe ContactMailer do
   describe '#send_email' do
     subject(:email) { described_class.send_email(attributes) }
 
-    let(:attributes) { valid_attributes[:contact] }
+    let(:from) { ['johndoe@test.fr'] }
+    let(:to) { ['contact@example.test'] }
+    let(:subject) { 'Message de contact' }
+    let(:body) { 'My contact message' }
 
-    it 'renders the subject' do
-      expect(email.subject).to eq(I18n.t('contact_mailer.send_email.subject'))
-    end
-
-    it 'renders the receiver email' do
-      expect(email.to).to eq([ENV.fetch('TO_CONTACT')])
-    end
-
-    it 'renders the sender email' do
-      expect(email.from).to eq(['johndoe@test.fr'])
-    end
-
-    it 'renders the body' do
-      expect(email.body.encoded).to match('My contact message')
-    end
+    it_behaves_like :email_with_headers
   end
 
   describe '#copy_email' do
-    subject(:copy) { described_class.copy_email(attributes) }
+    subject(:email) { described_class.copy_email(attributes) }
 
-    let(:attributes) { valid_attributes[:contact] }
+    let(:from) { ['contact@example.test'] }
+    let(:to) { ['johndoe@test.fr'] }
+    let(:subject) { 'Copie du message de contact' }
+    let(:body) { 'My contact message' }
 
-    it 'renders the subject' do
-      expect(copy.subject).to eq(I18n.t('contact_mailer.copy_email.subject'))
-    end
-
-    it 'renders the receiver email' do
-      expect(copy.to).to eq(['johndoe@test.fr'])
-    end
-
-    it 'renders the sender email' do
-      expect(copy.from).to eq([ENV.fetch('TO_CONTACT')])
-    end
-
-    it 'renders the body' do
-      expect(copy.body.encoded).to match('My contact message')
-    end
+    it_behaves_like :email_with_headers
   end
 end


### PR DESCRIPTION
Details:
- CREATE `mailers` shared examples
- UPDATE contact mailer spec to use this new shared example