### PR TITLE
FIX wrong folder for contact mailer locales

### DIFF
--- a/config/locales/contact_mailer/copy_email.yml
+++ b/config/locales/contact_mailer/copy_email.yml
@@ -1,6 +1,4 @@
 fr:
   contact_mailer:
-    send_email:
-      subject: Message de contact
     copy_email:
       subject: Copie du message de contact

--- a/config/locales/contact_mailer/send_email.fr.yml
+++ b/config/locales/contact_mailer/send_email.fr.yml
@@ -1,0 +1,9 @@
+fr:
+  contact_mailer:
+    send_email:
+      subject: Message de contact
+      copy_email: Voici une copie de l'email reçu par l'administrateur
+      hi: Bonjour %{name}
+      contact_informations: 'Informations de contact:'
+      phone: 'Téléphone:'
+      email: 'Email:'

--- a/config/locales/mailers/contacts/send_email.fr.yml
+++ b/config/locales/mailers/contacts/send_email.fr.yml
@@ -1,9 +1,0 @@
-fr:
-  mailers:
-    contacts:
-      send_email:
-        copy_email: Voici une copie de l'email reçu par l'administrateur
-        hi: Bonjour %{name}
-        contact_informations: 'Informations de contact:'
-        phone: 'Téléphone:'
-        email: 'Email:'


### PR DESCRIPTION
Details:
- MOVE `contact` mailers locales to correct folder