### PR TITLE
ADD rails_db gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,7 @@ group :development do
   gem 'better_errors'
   gem 'binding_of_caller'
 
+  gem 'rails_db'
   gem 'listen'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,8 @@ GEM
       simplecov
     codeclimate-test-reporter (1.0.8)
       simplecov (<= 0.13)
+    codemirror-rails (5.16.0)
+      railties (>= 3.0, < 6.0)
     coderay (1.1.2)
     color_route (3.0.0)
       colorize (~> 0.7)
@@ -225,6 +227,8 @@ GEM
     parser (2.4.0.0)
       ast (~> 2.2)
     pg (0.21.0)
+    polyamorous (1.3.1)
+      activerecord (>= 3.0)
     powerpack (0.1.1)
     premailer (1.10.4)
       addressable
@@ -280,6 +284,13 @@ GEM
     rails-i18n (5.0.4)
       i18n (~> 0.7)
       railties (~> 5.0)
+    rails_db (1.6.0)
+      codemirror-rails
+      kaminari
+      rails (>= 3.1.0)
+      ransack
+      simple_form
+      terminal-table
     railties (5.1.4)
       actionpack (= 5.1.4)
       activesupport (= 5.1.4)
@@ -289,6 +300,12 @@ GEM
     rainbow (2.2.2)
       rake
     rake (12.1.0)
+    ransack (1.8.3)
+      actionpack (>= 3.0)
+      activerecord (>= 3.0)
+      activesupport (>= 3.0)
+      i18n
+      polyamorous (~> 1.3)
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
@@ -403,6 +420,8 @@ GEM
     sqlite3 (1.3.13)
     sysexits (1.2.0)
     temple (0.8.0)
+    terminal-table (1.8.0)
+      unicode-display_width (~> 1.1, >= 1.1.1)
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -473,6 +492,7 @@ DEPENDENCIES
   rails (~> 5.1.3)
   rails-controller-testing
   rails-i18n (~> 5.0.0)
+  rails_db
   reform-rails
   ribbonit
   rspec-rails (~> 3.5)


### PR DESCRIPTION
`rails_db` allow to manage database directly from the rails application
through `http://localhost:3000/rails/db`. It is a very good solution
for `sqlite` adapter.

Details:
- ADD `rails_db` gem in `development`