### PR TITLE
UPDATE gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,7 @@ GEM
     capybara-screenshot (1.0.17)
       capybara (>= 1.0, < 3)
       launchy
-    carrierwave (1.1.0)
+    carrierwave (1.2.0)
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
       mime-types (>= 1.16)
@@ -111,6 +111,7 @@ GEM
     colored (1.2)
     colorize (0.8.1)
     concurrent-ruby (1.0.5)
+    crass (1.0.2)
     css_parser (1.6.0)
       addressable
     database_cleaner (1.6.1)
@@ -140,7 +141,7 @@ GEM
       faraday
       multi_json
     erubi (1.6.1)
-    factory_girl (4.8.0)
+    factory_girl (4.8.1)
       activesupport (>= 3.0.0)
     factory_girl_rails (4.8.0)
       factory_girl (~> 4.8.0)
@@ -193,7 +194,8 @@ GEM
       activesupport (>= 4, < 5.2)
       railties (>= 4, < 5.2)
       request_store (~> 1.0)
-    loofah (2.0.3)
+    loofah (2.1.1)
+      crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.6.6)
       mime-types (>= 1.16, < 4)
@@ -203,7 +205,7 @@ GEM
       callsite (~> 0.0, >= 0.0.11)
       rack-contrib (>= 1.1, < 3)
       railties (>= 3.0.0, < 5.2.0)
-    method_source (0.8.2)
+    method_source (0.9.0)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
@@ -238,9 +240,9 @@ GEM
     premailer-rails (1.9.7)
       actionmailer (>= 3, < 6)
       premailer (~> 1.7, >= 1.7.9)
-    pry (0.11.0)
+    pry (0.11.1)
       coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
+      method_source (~> 0.9.0)
     pry-alias (0.0.1)
       binding_of_caller
       pry
@@ -354,10 +356,10 @@ GEM
       rainbow (>= 2.2.2, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    rubocop-rspec (1.17.1)
+    rubocop-rspec (1.18.0)
       rubocop (>= 0.50.0)
     ruby-graphviz (1.2.3)
-    ruby-progressbar (1.8.3)
+    ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
     rubyzip (1.2.1)
     sass (3.5.1)
@@ -380,7 +382,7 @@ GEM
       activemodel (>= 4.1)
       elasticsearch (>= 1)
       hashie
-    selenium-webdriver (3.5.2)
+    selenium-webdriver (3.6.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
     shog (0.1.9)


### PR DESCRIPTION
* carrierwave 1.1.0 → 1.2.0
[changelog](https://github.com/carrierwaveuploader/carrierwave/blob/master/CHANGELOG.md#120---2017-09-30)

* factory_girl 4.8.0 → 4.8.1
[changelog](https://github.com/thoughtbot/factory_girl/blob/master/NEWS)

* loofah 2.0.3 → 2.1.1
[changelog](https://github.com/flavorjones/loofah/blob/master/CHANGELOG.md#211--2017-09-24)

* method_source 0.8.2 → 0.9.0

* pry 0.11.0 → 0.11.1
[changelog](https://github.com/pry/pry/blob/master/CHANGELOG.md#0974-2011115)

* rubocop-rspec 1.17.1 → 1.18.0
[changelog](https://github.com/backus/rubocop-rspec/blob/master/CHANGELOG.md#1180-2017-09-29)

* ruby-progressbar 1.8.3 → 1.9.0
[changelog](https://github.com/jfelchner/ruby-progressbar/blob/master/CHANGELOG.md#version-v190---september-27-2017)

* selenium-webdriver 3.5.2 → 3.6.0
[changelog](https://github.com/SeleniumHQ/selenium/blob/master/rb/CHANGES)