### PR TITLE
USE human_attribute_name method

### DIFF
--- a/app/views/admin/blogs/_table.slim
+++ b/app/views/admin/blogs/_table.slim
@@ -1,12 +1,8 @@
 table.hover
   thead
     tr
-      th= t('.cover')
-      th= t('.title')
-      th= t('.category')
-      - if params[:action] != 'show'
-        th= t('.author')
-      th= t('actions')
+      - %i[cover title category author actions].each do |attribute|
+        th= Blog.human_attribute_name(attribute)
 
   tbody
     - blogs.each do |blog|
@@ -15,10 +11,9 @@ table.hover
         td= link_to blog.title, category_blog_path(blog.category, blog)
         td= link_to blog.category_name, category_blogs_path(blog.category)
 
-        - if params[:action] != 'show'
-          td
-            = link_to blog.user_username, user_path(blog.user)
-            small =< "(#{blog.user_role})"
+        td
+          = link_to blog.user_username, user_path(blog.user)
+          small =< "(#{blog.user_role})"
 
         td
           = show_button_to category_blog_path(blog.category, blog) if can?(:read, blog)

--- a/app/views/admin/categories/_table.slim
+++ b/app/views/admin/categories/_table.slim
@@ -1,9 +1,8 @@
 table.hover
   thead
     tr
-      th= t('.name')
-      th= t('.blogs_count')
-      th= t('actions')
+      - %i[name blogs_count actions].each do |attribute|
+        th= Category.human_attribute_name(attribute)
 
   tbody
     - @categories.each do |category|

--- a/config/locales/activerecord.fr.yml
+++ b/config/locales/activerecord.fr.yml
@@ -1,0 +1,18 @@
+attributes: &attributes
+  blog:
+    author: Auteur
+    category: Catégorie
+    category_id: Catégorie
+    content: Contenu
+    cover: Couverture
+    tag_list: Liste de tags
+    title: Titre
+  category:
+    blogs_count: Nombre d'articles de Blog
+    name: Nom
+
+fr:
+  activemodel:
+    attributes: *attributes
+  activerecord:
+    attributes: *attributes

--- a/config/locales/admin/blogs/_table.fr.yml
+++ b/config/locales/admin/blogs/_table.fr.yml
@@ -1,8 +1,0 @@
-fr:
-  admin:
-    blogs:
-      table:
-        cover: Couverture
-        title: Titre
-        category: Catégorie
-        author: Auteur

--- a/config/locales/admin/categories/_table.fr.yml
+++ b/config/locales/admin/categories/_table.fr.yml
@@ -1,6 +1,0 @@
-fr:
-  admin:
-    categories:
-      table:
-        name: Nom
-        blogs_count: Nombre d'articles de Blog

--- a/config/locales/simple_form/labels.fr.yml
+++ b/config/locales/simple_form/labels.fr.yml
@@ -1,11 +1,11 @@
 fr:
   simple_form:
     labels:
-      blog:
-        title: Titre
-        content: Contenu
-        category_id: Catégorie
-        tag_list: Liste de tags
+      contact:
+        copy: Recevoir une copie ?
+        email: Email
+        message: Message
+        name: Nom
       user:
         username: Nom d'utilisateur
         password: Mot de passe
@@ -13,8 +13,3 @@ fr:
         current_password: Mot de passe actuel
         new_password: Nouveau mot de passe
         new_password_confirmation: Confirmation du nouveau mot de passe
-      contact:
-        name: Nom
-        email: Email
-        message: Message
-        copy: Recevoir une copie ?


### PR DESCRIPTION
In order to avoid repeating keys between views and forms,
it is a good practice to use the `human_attribute_name`
method and to define translations in `activerecord` and
`activerecord` i18n scopes.

Details:
- REMOVE unused partials
- USE `human_attribute_name` in views
- REWRITE `i18n` keys by alphabetical order